### PR TITLE
Upgraded to OpenSearch 1.2.3.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,6 @@ jobs:
           - ubuntu-latest
           - macOS-latest
         java:
-          - 11
           - 14
     name: Build and Test Plugin Template
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,9 +12,14 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [14]
+        os:
+          - ubuntu-latest
+          - macOS-latest
+        java:
+          - 11
+          - 14
     name: Build and Test Plugin Template
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2
@@ -25,4 +30,4 @@ jobs:
 
     - name: Build and Run Tests
       run: |
-          ./gradlew build -Dopensearch.version=1.1.0
+          ./gradlew build -Dopensearch.version=1.2.1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,4 +30,4 @@ jobs:
 
     - name: Build and Run Tests
       run: |
-          ./gradlew build -Dopensearch.version=1.2.1
+          ./gradlew build -Dopensearch.version=1.2.3

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ nbactions.xml
 # gradle stuff
 .gradle/
 build/
+bin/
 
 # vscode stuff
 .vscode/

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ validateNebulaPom.enabled = false
 
 buildscript {
     ext {
-        opensearch_version = "1.1.0-SNAPSHOT"
+        opensearch_version = "1.2.1-SNAPSHOT"
     }
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ validateNebulaPom.enabled = false
 
 buildscript {
     ext {
-        opensearch_version = "1.2.1-SNAPSHOT"
+        opensearch_version = "1.2.3-SNAPSHOT"
     }
 
     repositories {


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

- Upgraded to OpenSearch 1.2.3
- Expanded build matrix to MacOS
- Added bin to .gitignore
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
