### PR TITLE
[CI] Remove hardcoded `opensearch.version` from CI Build job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,4 +29,4 @@ jobs:
 
     - name: Build and Run Tests
       run: |
-          ./gradlew build -Dopensearch.version=1.2.3
+          ./gradlew build


### PR DESCRIPTION
### Description

OpenSearch version is typically specified in `build.gradle` file (or in `gradle.properties` file which is currently not present in this template). However, as of writing the CI job for this template silently overrides this value to whatever is hardcoded in `CI.yml` file. This leads to two issues:

- when the template code is upgraded to a new version of OpenSearch the version needs to be changed at least in two places (which is prone to errors)
- if the plugin author is using GHA then most likely he/she is not aware of the fact that the CI job is overriding the version (a missing docs is to blame?) and they can face unexpected failures of the job

If the `opensearch.version` needs to be overridden for the CI job I suggest documenting it properly and giving plugin authors instructions on **how** and **when** to modify the version in CI.yml file.

### Issues Resolved
Closes #21

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Lukáš Vlček <lukas.vlcek@aiven.io>