### PR TITLE
Add support for reproducible builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,12 @@ task integTest(type: RestIntegTestTask) {
 }
 tasks.named("check").configure { dependsOn(integTest) }
 
+// https://docs.gradle.org/current/userguide/working_with_files.html#sec:reproducible_archives
+tasks.withType(AbstractArchiveTask).configureEach {
+    preserveFileTimestamps = false
+    reproducibleFileOrder = true
+}
+
 integTest {
     // The --debug-jvm command-line option makes the cluster debuggable; this makes the tests debuggable
     if (System.getProperty("test.debug") != null) {


### PR DESCRIPTION
### Description
As per gradle [docs] add support to remove timestamps and package with same order which is required from [reproducible] builds

[docs]: https://docs.gradle.org/current/userguide/working_with_files.html#sec:reproducible_archives
[reproducible]: https://reproducible-builds.org/

### Issues Resolved
As per the suggestion in the `opensearch-project/anomaly-detection` PR [579](https://github.com/opensearch-project/anomaly-detection/pull/579#issuecomment-1258078995)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
