### PR TITLE
The name of plugin is not reported consistently

### DIFF
--- a/src/test/java/org/opensearch/path/to/plugin/RenamePluginIT.java
+++ b/src/test/java/org/opensearch/path/to/plugin/RenamePluginIT.java
@@ -10,15 +10,20 @@ package org.opensearch.path.to.plugin;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import org.apache.hc.core5.http.ParseException;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.opensearch.action.admin.cluster.node.info.NodeInfo;
+import org.opensearch.action.admin.cluster.node.info.NodesInfoResponse;
+import org.opensearch.action.admin.cluster.node.info.PluginsAndModules;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.plugins.Plugin;
+import org.opensearch.plugins.PluginInfo;
 import org.opensearch.test.OpenSearchIntegTestCase;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 import static org.hamcrest.Matchers.containsString;
 
@@ -37,5 +42,54 @@ public class RenamePluginIT extends OpenSearchIntegTestCase {
 
         logger.info("response body: {}", body);
         assertThat(body, containsString("rename"));
+    }
+
+    public void testPluginNames() {
+        NodesInfoResponse response = client().admin().cluster().prepareNodesInfo().clear().addMetric("plugins").get();
+        assertEquals(0, response.failures().size());
+        assertFalse(response.getNodes().isEmpty());
+        List<NodeInfo> nodes = response.getNodes();
+        for (NodeInfo ni : nodes) {
+            assertNotNull(ni.getInfo(PluginsAndModules.class));
+
+            // The following test would fail!
+            /*
+            assertEquals(
+                    1,
+                    ni.getInfo(PluginsAndModules.class).getPluginInfos().stream().filter(
+                            pluginInfo -> pluginInfo.getName().equals("rename")
+                    ).count()
+            );
+            */
+
+            // Normally, I would expect that the plugin deployed into a node will report its name
+            // consistently. But it turns out that in some cases the plugin returns value of its classname
+            // instead of the 'name'.
+            //
+            // Depending on what role the node has, but it seems that there are nodes that have also
+            // two additional plugins deployed: MockNioTransportPlugin and MockHttpTransport$TestPlugin
+            // and in this case the plugins name is a classname (also their description is a "classpath plugin").
+            //
+            // You can setup a breakpoint on the line below and investigate all plugins from particular node.
+
+            List<PluginInfo> pluginInfos = ni.getInfo(PluginsAndModules.class).getPluginInfos();
+            if (pluginInfos.size() > 1) {
+                assertEquals(
+                        1,
+                        ni.getInfo(PluginsAndModules.class).getPluginInfos().stream().filter(
+                                pluginInfo -> pluginInfo.getName().equals("org.opensearch.path.to.plugin.RenamePlugin")
+                        ).count()
+                );
+            } else if (pluginInfos.size() == 1) {
+                assertEquals(
+                        1,
+                        ni.getInfo(PluginsAndModules.class).getPluginInfos().stream().filter(
+                                pluginInfo -> pluginInfo.getName().equals("rename")
+                        ).count()
+                );
+            } else {
+                fail("Unexpected");
+            }
+        }
     }
 }


### PR DESCRIPTION
### Description

I realized that plugin names are note represented correctly according to plugin configuration in testing framework.

Please see code in this PR for more details. This PR is not meant to be merged, it is to demonstrate an issue.

More specifically, in tests based on `OpenSearchIntegTestCase` (ie, number of nodes and their configuration is variable) I can not expect that following code to work correctly:

```java
NodesInfoResponse response = client().admin().cluster().prepareNodesInfo().clear().addMetric("plugins").get();
for (NodeInfo ni : response.getNodes()) {
      assertEquals(
              1,
              ni.getInfo(PluginsAndModules.class).getPluginInfos().stream().filter(
                      pluginInfo -> pluginInfo.getName().equals("rename")
              ).count()
      );
}
```
It turns out that on some nodes the plugin returns its classname as a value of the `getName()`;

Maybe it is a consequence of how individual nodes and plugins are deployed into cluster in testing framework. However, it came as a surprise to me.

### Issues Resolved

As of writing I am not aware of any opened issue. It may not be an issue if this is the design on testing framework (however, it is not documented).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
