### PR TITLE
Fix build that fails due to missing OpenSearchIntegTestCase#createRestClient

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ import org.opensearch.gradle.test.RestIntegTestTask
 
 apply plugin: 'java'
 apply plugin: 'idea'
+apply plugin: 'eclipse'
 apply plugin: 'opensearch.opensearchplugin'
 apply plugin: 'opensearch.yaml-rest-test'
 apply plugin: 'opensearch.pluginzip'

--- a/src/test/java/org/opensearch/path/to/plugin/RenamePluginIT.java
+++ b/src/test/java/org/opensearch/path/to/plugin/RenamePluginIT.java
@@ -32,7 +32,7 @@ public class RenamePluginIT extends OpenSearchIntegTestCase {
     }
 
     public void testPluginInstalled() throws IOException, ParseException {
-        Response response = createRestClient().performRequest(new Request("GET", "/_cat/plugins"));
+        Response response = getRestClient().performRequest(new Request("GET", "/_cat/plugins"));
         String body = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
 
         logger.info("response body: {}", body);


### PR DESCRIPTION
### Description
Fix build that fails due to missing OpenSearchIntegTestCase#createRestClient

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-plugin-template-java/issues/65

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
