### PR TITLE
adapt to OpenSearch 2.x

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,4 +39,4 @@ jobs:
       if: matrix.os != 'windows-latest'
       run: |
           # Task to auto update version to the next development iteration
-          ./gradlew updateVersion -DnewVersion=2.1.0-SNAPSHOT
+          ./gradlew updateVersion -DnewVersion=2.15.0-SNAPSHOT

--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ validateNebulaPom.enabled = false
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "3.0.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.14.0")
     }
 
     repositories {
@@ -113,6 +113,8 @@ testClusters.integTest {
 run {
     useCluster testClusters.integTest
 }
+
+dependencyLicenses.enabled = false
 
 // updateVersion: Task to auto update version to the next development iteration
 task updateVersion {

--- a/src/test/java/org/opensearch/path/to/plugin/RenamePluginIT.java
+++ b/src/test/java/org/opensearch/path/to/plugin/RenamePluginIT.java
@@ -8,8 +8,8 @@
 package org.opensearch.path.to.plugin;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
-import org.apache.hc.core5.http.ParseException;
-import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.http.ParseException;
+import org.apache.http.util.EntityUtils;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.plugins.Plugin;


### PR DESCRIPTION
### Description
**DO NOT MERGE INTO `main`**

this adapts the template to OpenSearch 2.x (currently: `2.15.0-SNAPSHOT`).
as there's no 2.x branch on this repo yet i can only target the `main` branch. i'd suggest that you create a 2.x branch (based off of main; can only be done by maintainers) and then re-target this PR to the 2.x branch.

### Issues Resolved
resolves #66

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
