### PR TITLE
enable dependabot for java + GHA (backport to 2.x)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependabot"
+      - "dependencies"
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependabot"
+      - "dependencies"


### PR DESCRIPTION
### Description
this will enable dependabot updates, as it is also done for other OpenSearch projects.
while this project currently doesn't have any java dependencies it still makes sense to enable it here since this is a template repository and projects created based on it will usually have such dependencies in the future.

this is a cherry-pick of #73 for the `2.x` branch

### Issues Resolved
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
