### PR TITLE
Set opensearch-plugin-template-java plugin 3.0.0 baseline JDK version to JDK-21

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,8 +17,8 @@ jobs:
           - macOS-latest
           - windows-latest
         java:
-          - 17
           - 21
+          - 23
     name: Build and Test Plugin Template
     runs-on: ${{ matrix.os }}
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,11 @@ def pathToPlugin = 'path.to.plugin'
 def pluginClassName = 'RenamePlugin'
 group = "RenameGroup"
 
+java {
+    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_21
+}
+
 tasks.register("preparePluginPathDirs") {
     mustRunAfter clean
     doLast {


### PR DESCRIPTION
### Description
Set opensearch-plugin-template-java plugin 3.0.0 baseline JDK version to JDK-21

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-plugin-template-java/issues/70

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
