### PR TITLE
[Backport] [2.x] Update Andriy Redko (https://github.com/reta) affiliation

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,4 +9,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Amitai Stern             | [AmiStrn](https://github.com/AmiStrn)                   | Logz.io     |
 | Daniel "dB." Doubrovkine | [dblock](https://github.com/dblock)                     | Amazon      |
 | Sarat Vemulapalli        | [saratvemulapalli](https://github.com/saratvemulapalli) | Amazon      |
-| Andriy Redko             | [reta](https://github.com/reta)                         | Aiven       |
+| Andriy Redko             | [reta](https://github.com/reta)                         | Independent |


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/opensearch-plugin-template-java/pull/103 to `2.x`