### PR TITLE
Apply java-agent plugin to fix ClassNotFound issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ apply plugin: 'eclipse'
 apply plugin: 'opensearch.opensearchplugin'
 apply plugin: 'opensearch.yaml-rest-test'
 apply plugin: 'opensearch.pluginzip'
+apply plugin: 'opensearch.java-agent'
 
 def pluginName = 'rename'
 def pluginDescription = 'Custom plugin'


### PR DESCRIPTION
### Description

Apply java-agent plugin to fix ClassNotFound issue

All plugins in the default distribution have this added since OpenSearch 3.0.0: https://github.com/opensearch-project/index-management/pull/1406

### Issues Resolved

Fixes: https://github.com/opensearch-project/opensearch-plugin-template-java/issues/105

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
